### PR TITLE
Lazy loading sur les photos des gens

### DIFF
--- a/src/views/Private/Members/MembersDetail.vue
+++ b/src/views/Private/Members/MembersDetail.vue
@@ -17,6 +17,7 @@
             <div class="shrink-0">
               <div class="relative size-16 rounded-full bg-gray-200">
                 <img
+                  loading="lazy"
                   v-if="member.thumbnail"
                   :alt="`${$t('members.detail.profile.picture.label')} - ${fullname}`"
                   class="size-full rounded-full object-cover object-top"

--- a/src/views/Private/Members/MembersDetail.vue
+++ b/src/views/Private/Members/MembersDetail.vue
@@ -17,10 +17,10 @@
             <div class="shrink-0">
               <div class="relative size-16 rounded-full bg-gray-200">
                 <img
-                  loading="lazy"
                   v-if="member.thumbnail"
                   :alt="`${$t('members.detail.profile.picture.label')} - ${fullname}`"
                   class="size-full rounded-full object-cover object-top"
+                  loading="lazy"
                   :src="member.thumbnail" />
                 <SvgIcon
                   v-else

--- a/src/views/Private/Members/MembersListCard.vue
+++ b/src/views/Private/Members/MembersListCard.vue
@@ -5,6 +5,7 @@
         <template v-if="member">
           <img
             v-if="member.thumbnail"
+            loading="lazy"
             :alt="`${$t('members.detail.profile.picture.label')} - ${fullname}`"
             class="size-full rounded-full object-cover object-top"
             :src="member.thumbnail" />

--- a/src/views/Private/Members/MembersListCard.vue
+++ b/src/views/Private/Members/MembersListCard.vue
@@ -5,9 +5,9 @@
         <template v-if="member">
           <img
             v-if="member.thumbnail"
-            loading="lazy"
             :alt="`${$t('members.detail.profile.picture.label')} - ${fullname}`"
             class="size-full rounded-full object-cover object-top"
+            loading="lazy"
             :src="member.thumbnail" />
           <span
             v-if="member.attending"


### PR DESCRIPTION
## The problem
Permet d'éviter que toutes les images soient apellée en même temps. Le navigateur ne va apeller que celles qui sont visibles, et va gérer ensuite au scroll

## How to test it manually
Charger la page des membres avec l'onglet devtools reseau ouvert : seulement les images visibles sont chargées

