### PR TITLE
feat: show badge indicator for members

### DIFF
--- a/src/views/Private/Members/MembersListCard.vue
+++ b/src/views/Private/Members/MembersListCard.vue
@@ -15,6 +15,14 @@
           <template v-if="member">
             <p class="shrink-0 font-medium text-indigo-600 sm:text-sm">
               {{ fullname }}
+              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+              <span
+                v-if="member?.badgeId"
+                aria-label="badge"
+                class="ml-1"
+                role="img"
+                :title="member.badgeId"
+                v-text="badgeEmoji" />
             </p>
 
             <p class="mt-1 flex w-full items-center text-sm text-gray-500">
@@ -114,4 +122,6 @@ const props = defineProps({
 const fullname = computed<string>(() =>
   [props.member?.firstName, props.member?.lastName].filter(Boolean).join(' '),
 );
+
+const badgeEmoji = '🪪';
 </script>


### PR DESCRIPTION
## Summary
- display badge emoji next to member names when badge ID exists

## Testing
- `npm run check` *(fails: TS6133 errors in SideDialog.vue, MembershipsListPanel.vue, SubscriptionsListPanel.vue, TicketsListPanel.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68c1427d55d0832f8f513157c3fcb4a4