### PR TITLE
feat(members): Editer les attributs du membre dans manager, qu'ils soient locaux ou stockés dans wordpress

### DIFF
--- a/src/i18n/locales/en-GB/members.json
+++ b/src/i18n/locales/en-GB/members.json
@@ -117,6 +117,10 @@
       "title": "Orders"
     },
     "profile": {
+      "activityType": {
+        "description": "",
+        "label": "Activity type"
+      },
       "attending": "Currently attending{location}",
       "badge": {
         "description": "Identifier of the badge assigned by Bliiida and used to access the location.",
@@ -125,6 +129,10 @@
       },
       "birthdate": {
         "label": "Birthdate"
+      },
+      "canPayByBankTransfer": {
+        "description": "The \"Bank transfer\" payment method is only offered to the member when this option is enabled.",
+        "label": "Can pay by bank transfer"
       },
       "capabilities": {
         "apply": "Update capabilities",
@@ -150,8 +158,9 @@
             "label": "Key Box Access"
           },
           "MANAGER": {
-            "description": "Manage members and services as well as access all features. Basically: full powers.\nThis setting is changed on the Wordpress profile.",
-            "label": "Administrator"
+            "description": "Manage members and services, and access every feature. Basically: full powers.",
+            "label": "Administrator",
+            "readonly": "Manage members and services, and access every feature. Basically: full powers.\nThis account holds several WordPress roles: the change must be made on the WordPress profile itself."
           },
           "PARKING_ACCESS": {
             "description": "Open the parking barrier.",
@@ -182,9 +191,21 @@
       "firstname": {
         "label": "First Name"
       },
+      "isBoardCandidate": {
+        "description": "Is running for the board at the next general meeting.",
+        "label": "Board candidate at the next general meeting"
+      },
+      "isEligibleToReducedRate": {
+        "description": "Reserved for students and job seekers. Without this option, products in the \"Reduced rates\" category cannot be purchased.",
+        "label": "Eligible to reduced rates"
+      },
       "lastSeen": "Last seen {date}{location}",
       "lastname": {
         "label": "Last Name"
+      },
+      "legalStatus": {
+        "description": "",
+        "label": "Legal status"
       },
       "location": {
         "cantina": "{' '}inside Cantina",
@@ -214,6 +235,14 @@
       },
       "picture": {
         "label": "Profile Picture"
+      },
+      "polaroidDescription": {
+        "description": "",
+        "label": "Description on the polaroid"
+      },
+      "polaroidName": {
+        "description": "",
+        "label": "Name on the polaroid"
       },
       "since": {
         "label": "Member since"

--- a/src/i18n/locales/fr-FR/members.json
+++ b/src/i18n/locales/fr-FR/members.json
@@ -117,6 +117,10 @@
       "title": "Commandes"
     },
     "profile": {
+      "activityType": {
+        "description": "",
+        "label": "Type d'activité"
+      },
       "attending": "Actuellement présent⸱e{location}",
       "badge": {
         "description": "Le numéro ou identifiant du badge attribué par Bliiida et utilisé pour accéder au tiers lieu.",
@@ -125,6 +129,10 @@
       },
       "birthdate": {
         "label": "Date de naissance"
+      },
+      "canPayByBankTransfer": {
+        "description": "Le moyen de paiement « Virement » n'est proposé au membre que si cette option est active.",
+        "label": "Peut payer par virement bancaire"
       },
       "capabilities": {
         "apply": "Modifier les capacités",
@@ -150,8 +158,9 @@
             "label": "Accès à la boîte à clés"
           },
           "MANAGER": {
-            "description": "Gérer les membres et les services ainsi qu'accéder à toutes les fonctionnalités. En gros : les pleins pouvoirs.\nCe paramètre se change sur le profil Wordpress.",
-            "label": "Administrateur"
+            "description": "Gérer les membres et les services ainsi qu'accéder à toutes les fonctionnalités. En gros : les pleins pouvoirs.",
+            "label": "Administrateur",
+            "readonly": "Gérer les membres et les services ainsi qu'accéder à toutes les fonctionnalités. En gros : les pleins pouvoirs.\nCe compte porte plusieurs rôles WordPress : le changement doit se faire directement sur le profil WordPress."
           },
           "PARKING_ACCESS": {
             "description": "Ouvrir la barrière du parking.",
@@ -182,9 +191,21 @@
       "firstname": {
         "label": "Prénom"
       },
+      "isBoardCandidate": {
+        "description": "Se porte candidat au Conseil d'Administration lors de la prochaine Assemblée Générale.",
+        "label": "Candidat au CA à la prochaine AG"
+      },
+      "isEligibleToReducedRate": {
+        "description": "Réservé aux étudiants et aux personnes en recherche d'emploi. Sans cette option, les produits de la catégorie « Tarifs réduits » ne sont pas achetables.",
+        "label": "Éligible aux tarifs réduits"
+      },
       "lastSeen": "Présent⸱e pour la dernière fois {date}{location}",
       "lastname": {
         "label": "Nom"
+      },
+      "legalStatus": {
+        "description": "",
+        "label": "Statut juridique"
       },
       "location": {
         "cantina": "{' '}dans la Cantina",
@@ -215,6 +236,14 @@
       "picture": {
         "label": "Photo de profil"
       },
+      "polaroidDescription": {
+        "description": "",
+        "label": "Description sur le polaroid"
+      },
+      "polaroidName": {
+        "description": "",
+        "label": "Nom sur le polaroid"
+      },
       "since": {
         "label": "Membre depuis le"
       },
@@ -237,7 +266,7 @@
         "fail": "Impossible de synchroniser {name}",
         "success": "{name} synchronisé"
       },
-      "orders": "Consulter toutes les\u00A0commandes",
+      "orders": "Consulter toutes les commandes",
       "sync": "Synchroniser",
       "title": "Synchronisation avec Wordpress"
     }

--- a/src/services/api/members.ts
+++ b/src/services/api/members.ts
@@ -65,7 +65,26 @@ export interface Member extends MemberListItem {
   trustedUser: boolean; // with at least 10 days of totalActivity
   activeUser: boolean; // with at least 20 days of activity (in the last 180 days)
   badgeId?: string;
+  // Whether the admin flag can be toggled from here: some accounts hold several
+  // roles and must be changed in WordPress itself.
+  isAdminEditable: boolean;
+  canPayByBankTransfer: boolean;
+  isEligibleToReducedRate: boolean;
+  isBoardCandidate: boolean;
+  polaroidName: string;
+  polaroidDescription: string;
+  legalStatus: string;
+  activityType: string;
 }
+
+/**
+ * Values allowed for the member attributes backed by a closed list.
+ * Where they are actually stored is the API's business, not ours.
+ */
+export type MemberAttributes = {
+  legalStatus: string[];
+  activityType: string[];
+};
 
 export const isMembershipNonCompliant = (member: Member | MemberListItem) => {
   return Boolean(
@@ -99,7 +118,11 @@ export const getMember = (id: string): Promise<Member> => {
   return HTTP.get(`/api/members/${id}`).then(({ data }) => data);
 };
 
-export const updateMember = (id: string, member: Member): Promise<Member> => {
+/**
+ * Update a member. Send whichever attributes changed: the API knows where each
+ * of them is actually stored, and ignores the read-only ones.
+ */
+export const updateMember = (id: string, member: Partial<Member>): Promise<Member> => {
   return HTTP.put(`/api/members/${id}`, member).then(({ data }) => data);
 };
 
@@ -177,6 +200,10 @@ export const updateMemberCapabilities = (
   capabilities: Partial<MemberCapabilities>,
 ): Promise<MemberCapabilities> => {
   return HTTP.put(`/api/members/${id}/capabilities`, capabilities).then(({ data }) => data);
+};
+
+export const getMemberAttributes = (): Promise<MemberAttributes> => {
+  return HTTP.get('/api/members/attributes').then(({ data }) => data);
 };
 
 export const impersonateMember = (

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -43,6 +43,7 @@ export const membersQueryKeys = {
   historyById: (id: string | number) => [...membersQueryKeys.byId(id), 'history'] as const,
   capabilitiesById: (id: string | number) =>
     [...membersQueryKeys.byId(id), 'capabilities'] as const,
+  attributes: () => [...membersQueryKeys.all(), 'attributes'] as const,
   ticketsById: (id: string | number) => [...membersQueryKeys.byId(id), 'tickets'] as const,
   subscriptionsById: (id: string | number) =>
     [...membersQueryKeys.byId(id), 'subscriptions'] as const,

--- a/src/views/Private/Members/Detail/MemberCapabilitesPanel.vue
+++ b/src/views/Private/Members/Detail/MemberCapabilitesPanel.vue
@@ -3,11 +3,16 @@
     <ul class="flex flex-col gap-4">
       <AppSwitchField
         as="li"
-        :description="$t('members.detail.profile.capabilities.values.MANAGER.description')"
-        disabled
+        :description="
+          member?.isAdminEditable
+            ? $t('members.detail.profile.capabilities.values.MANAGER.description')
+            : $t('members.detail.profile.capabilities.values.MANAGER.readonly')
+        "
+        :disabled="!member?.isAdminEditable"
         :label="$t('members.detail.profile.capabilities.values.MANAGER.label')"
         :loading="isFetchingMember"
-        :model-value="member?.isAdmin" />
+        :model-value="state.isAdmin"
+        @update:model-value="(enabled: boolean) => (state.isAdmin = enabled)" />
 
       <AppSwitchField
         v-for="capability in uniq([
@@ -87,6 +92,7 @@ import {
   getMember,
   getMemberCapabilities,
   MemberCapabilities,
+  updateMember,
   updateMemberCapabilities,
 } from '@/services/api/members';
 import { membersQueryKeys, useAppQuery } from '@/services/query';
@@ -111,6 +117,9 @@ const notificationsStore = useNotificationsStore();
 const i18n = useI18n();
 const state = reactive({
   capabilities: null as MemberCapabilities | null,
+  // The admin flag is a WordPress role, not one of our capabilities: it travels
+  // through the regular member update route.
+  isAdmin: false as boolean,
 
   isSubmitting: false as boolean,
   isResetDialogVisible: false as boolean,
@@ -157,7 +166,12 @@ const onSubmit = async () => {
   vuelidate.value.$reset();
 
   state.isSubmitting = true;
-  updateMemberCapabilities(props.memberId, state.capabilities as MemberCapabilities)
+  Promise.all([
+    updateMemberCapabilities(props.memberId, state.capabilities as MemberCapabilities),
+    state.isAdmin === Boolean(member.value?.isAdmin)
+      ? Promise.resolve()
+      : updateMember(props.memberId, { isAdmin: state.isAdmin }),
+  ])
     .then(() => {
       notificationsStore.addSuccessNotification(
         i18n.t('members.detail.profile.capabilities.onUpdate.success', {
@@ -166,6 +180,9 @@ const onSubmit = async () => {
       );
       queryClient.invalidateQueries({
         queryKey: membersQueryKeys.historyById(props.memberId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: membersQueryKeys.profileById(props.memberId),
       });
     })
     .catch(handleSilentError)
@@ -223,6 +240,14 @@ watch(
     if (memberCapabilities) {
       state.capabilities = { ...memberCapabilities };
     }
+  },
+  { immediate: true },
+);
+
+watch(
+  member,
+  (fetchedMember) => {
+    state.isAdmin = Boolean(fetchedMember?.isAdmin);
   },
   { immediate: true },
 );

--- a/src/views/Private/Members/Detail/MemberProfilePanel.vue
+++ b/src/views/Private/Members/Detail/MemberProfilePanel.vue
@@ -7,7 +7,6 @@
           v-model="state.firstname"
           autocomplete="given-name"
           class="min-w-48 shrink grow basis-0"
-          disabled
           :errors="vuelidate.firstname.$errors.map(({ $message }) => $message as string)"
           :label="$t('members.detail.profile.firstname.label')"
           :loading="isFetchingMember"
@@ -20,7 +19,6 @@
           v-model="state.lastname"
           autocomplete="family-name"
           class="min-w-48 shrink grow basis-0"
-          disabled
           :errors="vuelidate.lastname.$errors.map(({ $message }) => $message as string)"
           :label="$t('members.detail.profile.lastname.label')"
           :loading="isFetchingMember"
@@ -49,13 +47,49 @@
           v-model="state.birthdate"
           autocomplete="bday"
           class="min-w-48 shrink grow basis-0"
-          disabled
           :label="$t('members.detail.profile.birthdate.label')"
           :loading="isFetchingMember"
           name="birthdate"
           :prepend-icon="mdiCakeVariantOutline"
-          type="date"
-          @update:model-value="(birthdate) => (state.birthdate = birthdate)" />
+          type="date" />
+      </div>
+
+      <div class="flex flex-row flex-wrap gap-x-6">
+        <AppTextField
+          id="polaroid-name"
+          v-model="state.polaroidName"
+          class="min-w-48 shrink grow basis-0"
+          :label="$t('members.detail.profile.polaroidName.label')"
+          :loading="isFetchingMember"
+          name="polaroid-name"
+          type="text" />
+        <AppTextField
+          id="polaroid-description"
+          v-model="state.polaroidDescription"
+          class="min-w-48 shrink grow basis-0"
+          :label="$t('members.detail.profile.polaroidDescription.label')"
+          :loading="isFetchingMember"
+          name="polaroid-description"
+          type="text" />
+      </div>
+
+      <div class="flex flex-row flex-wrap gap-x-6">
+        <AppSelectField
+          id="legal-status"
+          v-model="state.legalStatus"
+          class="min-w-48 shrink grow basis-0"
+          :label="$t('members.detail.profile.legalStatus.label')"
+          :loading="isFetchingMember"
+          name="legal-status"
+          :options="attributes?.legalStatus ?? []" />
+        <AppSelectField
+          id="activity-type"
+          v-model="state.activityType"
+          class="min-w-48 shrink grow basis-0"
+          :label="$t('members.detail.profile.activityType.label')"
+          :loading="isFetchingMember"
+          name="activity-type"
+          :options="attributes?.activityType ?? []" />
       </div>
 
       <AppTextField
@@ -84,7 +118,19 @@
 
       <NFCScannerDialog
         v-model="state.isScannerVisible"
-        @update:identifier="(id) => (state.badgeId = id)" />
+        @update:identifier="(id: string) => (state.badgeId = id)" />
+
+      <ul class="mb-5 mt-2 flex flex-col gap-4">
+        <AppSwitchField
+          v-for="name in SWITCH_FIELDS"
+          :key="`member-attribute-${name}`"
+          as="li"
+          :description="$t(`members.detail.profile.${name}.description`)"
+          :label="$t(`members.detail.profile.${name}.label`)"
+          :loading="isFetchingMember"
+          :model-value="state[name]"
+          @update:model-value="(enabled: boolean) => (state[name] = enabled)" />
+      </ul>
 
       <AppAlert
         v-if="memberErrorText"
@@ -120,6 +166,8 @@
 import NFCScannerDialog from '@/components/NFCScannerDialog.vue';
 import AppAlert from '@/components/form/AppAlert.vue';
 import AppButtonPlain from '@/components/form/AppButtonPlain.vue';
+import AppSelectField from '@/components/form/AppSelectField.vue';
+import AppSwitchField from '@/components/form/AppSwitchField.vue';
 import AppTextField from '@/components/form/AppTextField.vue';
 import AppPanel from '@/components/layout/AppPanel.vue';
 import {
@@ -128,7 +176,7 @@ import {
   scrollToFirstError,
 } from '@/helpers/errors';
 import { withAppI18nMessage } from '@/i18n';
-import { getMember, updateMemberBagdeId } from '@/services/api/members';
+import { getMember, getMemberAttributes, updateMember } from '@/services/api/members';
 import { membersQueryKeys, useAppQuery } from '@/services/query';
 import { useNotificationsStore } from '@/store/notifications';
 import { mdiCakeVariantOutline, mdiCellphoneNfc, mdiCheckAll, mdiCreditCardOutline } from '@mdi/js';
@@ -138,6 +186,12 @@ import { email, required } from '@vuelidate/validators';
 import { compact } from 'lodash';
 import { computed, nextTick, reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+
+const SWITCH_FIELDS = [
+  'canPayByBankTransfer',
+  'isEligibleToReducedRate',
+  'isBoardCandidate',
+] as const;
 
 const props = defineProps({
   memberId: {
@@ -156,6 +210,14 @@ const state = reactive({
   birthdate: null as string | null,
   badgeId: null as string | null,
 
+  polaroidName: '' as string,
+  polaroidDescription: '' as string,
+  legalStatus: '' as string,
+  activityType: '' as string,
+  canPayByBankTransfer: false as boolean,
+  isEligibleToReducedRate: false as boolean,
+  isBoardCandidate: false as boolean,
+
   isSubmitting: false as boolean,
   hasFailValidationOnce: false as boolean,
 
@@ -170,6 +232,16 @@ const {
   computed(() => ({
     queryKey: membersQueryKeys.profileById(props.memberId),
     queryFn: () => getMember(props.memberId),
+  })),
+);
+
+// Values allowed for the fields backed by a closed list. Shared by every member,
+// hence cached longer than a profile.
+const { data: attributes } = useAppQuery(
+  computed(() => ({
+    queryKey: membersQueryKeys.attributes(),
+    queryFn: () => getMemberAttributes(),
+    staleTime: 60 * 60 * 1000, // 1 hour
   })),
 );
 
@@ -206,7 +278,20 @@ const onSubmit = async () => {
   vuelidate.value.$reset();
 
   state.isSubmitting = true;
-  updateMemberBagdeId(props.memberId, state.badgeId as string)
+  // A single call: the API dispatches each attribute to wherever it is stored.
+  updateMember(props.memberId, {
+    firstName: state.firstname ?? '',
+    lastName: state.lastname ?? '',
+    badgeId: state.badgeId as string,
+    birthDate: state.birthdate ?? '',
+    polaroidName: state.polaroidName,
+    polaroidDescription: state.polaroidDescription,
+    legalStatus: state.legalStatus,
+    activityType: state.activityType,
+    canPayByBankTransfer: state.canPayByBankTransfer,
+    isEligibleToReducedRate: state.isEligibleToReducedRate,
+    isBoardCandidate: state.isBoardCandidate,
+  })
     .then(() => {
       notificationsStore.addSuccessNotification(
         i18n.t('members.detail.profile.onUpdate.success', {
@@ -244,6 +329,14 @@ watch(
       state.email = fetchedMember.email || null;
       state.birthdate = fetchedMember.birthDate || null;
       state.badgeId = fetchedMember.badgeId || null;
+
+      state.polaroidName = fetchedMember.polaroidName ?? '';
+      state.polaroidDescription = fetchedMember.polaroidDescription ?? '';
+      state.legalStatus = fetchedMember.legalStatus ?? '';
+      state.activityType = fetchedMember.activityType ?? '';
+      state.canPayByBankTransfer = Boolean(fetchedMember.canPayByBankTransfer);
+      state.isEligibleToReducedRate = Boolean(fetchedMember.isEligibleToReducedRate);
+      state.isBoardCandidate = Boolean(fetchedMember.isBoardCandidate);
     }
   },
   { immediate: true },


### PR DESCRIPTION
Auparavant, le panneau de profil affichait les champs d'identité comme étant read only. Désormais, on peut les modifier tous via `PUT /api/members/:userId` (PR en attente sur tickets): nom et prénom, date de naissance, nom et description du Polaroid, statut juridique, type d'activité, virement bancaire, tarif réduit et candidature au conseil d'administration. (d'autres valeurs pourront etre ajoutée)

Toutes les données sont transmises en un seul appel. L'emplacement de stockage réel de chaque attribut relève de la responsabilité de l'API; par conséquent, aucune mention de WordPress n'apparaît ici. 

L'option d'administration devient modifiable lorsque l'API indique `isAdminEditable` ; dans le cas contraire, elle conserve son libellé en lecture seule.

L'adresse e-mail reste en lecture seule car il y a pas mal de conséquences à gérer dans le cas du changement d'email, donc on verra plus tard.



pour info : c'est claude code qui a fait les modifs ici car je suis largués sur la codebase. Mais j'ai quand meme tout relu, et tout testé